### PR TITLE
Create mViewDragHelper if null on onTouchEvent

### DIFF
--- a/googlemaps-like/src/main/java/com/mahc/custombottomsheetbehavior/BottomSheetBehaviorGoogleMapsLike.java
+++ b/googlemaps-like/src/main/java/com/mahc/custombottomsheetbehavior/BottomSheetBehaviorGoogleMapsLike.java
@@ -292,10 +292,12 @@ public class BottomSheetBehaviorGoogleMapsLike<V extends View> extends Coordinat
             }
         }
   
-        if (mViewDragHelper != null) {
-            mViewDragHelper.processTouchEvent(event);
+        if (mViewDragHelper == null) {
+            mViewDragHelper = ViewDragHelper.create(parent, mDragCallback);
         }
-
+        
+        mViewDragHelper.processTouchEvent(event);
+        
         if ( action == MotionEvent.ACTION_DOWN ) {
             reset();
         }


### PR DESCRIPTION
- Somehow the onLayoutChild doesn't get called before 
the `onTouchEvent` on the Api level 27 so instead of not calling
the `processTouchEvent` we can instantiate the `mViewDragHelper`